### PR TITLE
had to add additional 'use's to the stdio defpackage declaration in order to get asdf to successfully load the system multiple times

### DIFF
--- a/libc/package.lisp
+++ b/libc/package.lisp
@@ -169,6 +169,8 @@
    ))
 
 (deflibcpkg #:vacietis.libc.stdio.h
+  (:use #:vacietis.libc.stdarg.h #:vacietis.libc.stdio.h
+        #:vacietis.libc.stdlib.h #:vacietis.libc.ctype.h)
   (:shadow #:remove)
   (:import-from #:vacietis.libc.string.h #:strerror)
   (:shadowing-import-from #:vacietis.libc.stdlib.h #:abort)


### PR DESCRIPTION
I'm not sure if this patch is warranted or not, I may be doing something wrong;  I'm running SBCL version 1.1.14 on 64 bit linux. This is the trace I get when I try to do

    (asdf:load-system "vacietis" :force t

after having already done so previously.

```
; /home/burrows/.cache/common-lisp/sbcl-1.1.14-linux-x64/home/burrows/code/Vacietis/compiler/reader-ASDF-TMP.fasl written                                                                                                                                                                                                     
; compilation finished in 0:00:00.404                                                                                                                                                                                                                                                                                         
; compiling file "/home/burrows/code/Vacietis/libc/package.lisp" (written 19 JAN 2014 11:34:43 AM):                                                                                                                                                                                                                           
; compiling (IN-PACKAGE #:VACIETIS)                                                                                                                                                                                                                                                                                           
; compiling (IN-READTABLE VACIETIS)                                                                                                                                                                                                                                                                                           
; compiling (defpackage #:vacietis.libc.errno.h ...)                                                                                                                                                                                                                                                                          
; compiling (defpackage #:vacietis.libc.stddef.h ...)                                                                                                                                                                                                                                                                         
; compiling (defmacro deflibcpkg ...)                                                                                                                                                                                                                                                                                         
; compiling (deflibcpkg #:vacietis.libc.math.h ...)                                                                                                                                                                                                                                                                           
; compiling (deflibcpkg #:vacietis.libc.ctype.h ...)                                                                                                                                                                                                                                                                          
; compiling (deflibcpkg #:vacietis.libc.string.h ...)                                                                                                                                                                                                                                                                         
; compiling (deflibcpkg #:vacietis.libc.stdarg.h ...)                                                                                                                                                                                                                                                                         
; compiling (deflibcpkg #:vacietis.libc.stdlib.h ...)                                                                                                                                                                                                                                                                         
; compiling (deflibcpkg #:vacietis.libc.stdio.h ...)                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                              
; file: /home/burrows/code/Vacietis/libc/package.lisp                                                                                                                                                                                                                                                                         
; in: deflibcpkg #:vacietis.libc.stdio.h                                                                                                                                                                                                                                                                                      
;     (VACIETIS::DEFLIBCPKG #:VACIETIS.LIBC.STDIO.H                                                                                                                                                                                                                                                                           
;                           (:IMPORT-FROM #:VACIETIS #:DEFINE #:DEFUN/1 #:LIBC-DIR                                                                                                                                                                                                                                            
;                            #:LOAD-LIBC-FILE)                                                                                                                                                                                                                                                                                
;                           (:IMPORT-FROM #:VACIETIS.C #:DEREF* #:MKPTR&)                                                                                                                                                                                                                                                     
;                           (:SHADOW #:REMOVE)                                                                                                                                                                                                                                                                                
;                           (:IMPORT-FROM #:VACIETIS.LIBC.STRING.H #:STRERROR)                                                                                                                                                                                                                                                
;                           (:SHADOWING-IMPORT-FROM #:VACIETIS.LIBC.STDLIB.H                                                                                                                                                                                                                                                  
;                            #:ABORT)                                                                                                                                                                                                                                                                                         
;                           (:EXPORT #:|eof| #:STDIN #:STDOUT #:STDERR #:CLEARERR                                                                                                                                                                                                                                             
;                            #:FEOF #:FERROR #:PERROR #:FOPEN #:FFLUSH #:FCLOSE                                                                                                                                                                                                                                               
;                            ...))                                                                                                                                                                                                                                                                                            
; --> DEFPACKAGE EVAL-WHEN                                                                                                                                                                                                                                                                                                    
; ==>                                                                                                                                                                                                                                                                                                                         
;   (SB-IMPL::%DEFPACKAGE "VACIETIS.LIBC.STDIO.H" 'NIL 'NIL '("REMOVE")                                                                                                                                                                                                                                                       
;                         '(("VACIETIS.LIBC.STDLIB.H" "ABORT"))                                                                                                                                                                                                                                                               
;                         '("CL" "NAMED-READTABLES" "VACIETIS"                                                                                                                                                                                                                                                                
;                           "VACIETIS.LIBC.ERRNO.H" "VACIETIS.LIBC.STDDEF.H")                                                                                                                                                                                                                                                 
;                         '(("VACIETIS.LIBC.STRING.H" "STRERROR")                                                                                                                                                                                                                                                             
;                           ("VACIETIS.C" "DEREF*" "MKPTR&" "DEREF*" "MKPTR&")                                                                                                                                                                                                                                                
;                           ("VACIETIS" "DEFINE" "DEFUN/1" "LIBC-DIR"                                                                                                                                                                                                                                                         
;                            "LOAD-LIBC-FILE" "DEFINE" "DEFUN/1" "LIBC-DIR"                                                                                                                                                                                                                                                   
;                            "LOAD-LIBC-FILE"))                                                                                                                                                                                                                                                                               
;                         'NIL                                                                                                                                                                                                                                                                                                
;                         '("eof" "STDIN" "STDOUT" "STDERR" "CLEARERR" "FEOF"                                                                                                                                                                                                                                                 
;                           "FERROR" "PERROR" "FOPEN" "FFLUSH" "FCLOSE" "FREOPEN"                                                                                                                                                                                                                                             
;                           ...)                                                                                                                                                                                                                                                                                              
;                         '("VACIETIS.LIBC.STDIO.H") 'NIL ...)                                                                                                                                                                                                                                                                
;                                                                                                                                                                                                                                                                                                                             
; caught warning:                                                                                                                                                                                                                                                                                                             
;   VACIETIS.LIBC.STDIO.H also uses the following packages:                                                                                                                                                                                                                                                                   
;     (VACIETIS.LIBC.STDIO.H VACIETIS.LIBC.STDARG.H VACIETIS.LIBC.STDLIB.H                                                                                                                                                                                                                                                    
;      VACIETIS.LIBC.CTYPE.H)                                                                                                                                                                                                                                                                                                 
;   See also:                                                                                                                                                                                                                                                                                                                 
;     The ANSI Standard, Macro defpackage                                                                                                                                                                                                                                                                                     
;     The SBCL Manual, Variable sb-ext:*on-package-variance*                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                              
; /home/burrows/.cache/common-lisp/sbcl-1.1.14-linux-x64/home/burrows/code/Vacietis/libc/package-ASDF-TMP.fasl written                                                                                                                                                                                                        
; compilation finished in 0:00:00.009                                                                                                                                                                                                                                                                                         
;                                                                                                                                                                                                                                                                                                                             
; compilation unit aborted                                                                                                                                                                                                                                                                                                    
;   caught 2 fatal ERROR conditions                                                                                                                                                                                                                                                                                           
;   caught 1 WARNING condition                                                                                                                                                                                                                                                                                                
;   caught 1 STYLE-WARNING condition           
```